### PR TITLE
Bug 17833: Do not merge contacts (first commit)

### DIFF
--- a/projects/instantbird/config
+++ b/projects/instantbird/config
@@ -75,6 +75,7 @@ input_files:
   - filename: trac-16489.patch
   - filename: trac-17896.patch
   - filename: trac-17494.patch
+  - filename: trac-17833-merge-contact.patch
   - filename: version.patch
   - filename: search-context-menu.patch
   - filename: search-preferences-xul.patch

--- a/projects/instantbird/trac-17833-merge-contact.patch
+++ b/projects/instantbird/trac-17833-merge-contact.patch
@@ -1,0 +1,28 @@
+diff --git a/chat/components/src/imContacts.js b/chat/components/src/imContacts.js
+--- a/chat/components/src/imContacts.js
++++ b/chat/components/src/imContacts.js
+@@ -588,23 +588,7 @@
+                this._buddies.every(function(b) b._empty),
+ 
+   mergeContact: function(aContact) {
+-    // Avoid merging the contact with itself or merging into an
+-    // already removed contact.
+-    if (aContact.id == this.id || !(this.id in ContactsById))
+-      throw Components.results.NS_ERROR_INVALID_ARG;
+-
+-    this._ensureNotDummy();
+-    let contact = ContactsById[aContact.id]; // remove XPConnect wrapper
+-
+-    // Copy all the contact-only tags first, otherwise they would be lost.
+-    for each (let tag in contact.getTags())
+-      if (!contact._isTagInherited(tag))
+-        this.addTag(tag);
+-
+-    // Adopt each buddy. Removing the last one will delete the contact.
+-    for each (let buddy in contact.getBuddies())
+-      buddy.contact = this;
+-    this._updatePreferredBuddy();
++    return;
+   },
+   moveBuddyBefore: function(aBuddy, aBeforeBuddy) {
+     let buddy = BuddiesById[aBuddy.id]; // remove XPConnect wrapper


### PR DESCRIPTION
Let's discuss disabling contacts merge. There are two ways of doing this, I am starting with the most recently discussed.

1). Return early and disable all contact merges, including ones to different tags (this commit).
2). Disable only the contact merge but allow contact tag merges.

I am OK with both but I am starting with 1)
