### PR TITLE
Trac 20062: Make stripping signatures reproducible on Tor Messenger .exe files 

### DIFF
--- a/projects/tor-messenger/build
+++ b/projects/tor-messenger/build
@@ -91,6 +91,10 @@ cd ..
 mv bundle tor-messenger
 [% IF c('var/windows') -%]
 makensis tor-messenger.nsi
+mv tor-messenger-install.exe tor-messenger-install-tmp.exe
+python pe_checksum_fix.py
+mv tor-messenger-install-tmp2.exe tor-messenger-install.exe
+rm tor-messenger-install-tmp.exe
 mv tor-messenger-install.exe [% dest_dir _ '/' _ c('filename') %]
 [% ELSE -%]
 [% c('tar', {

--- a/projects/tor-messenger/config
+++ b/projects/tor-messenger/config
@@ -26,6 +26,8 @@ input_files:
     enable: '[% c("var/osx") %]'
   - filename: tor-messenger.nsi
     enable: '[% c("var/windows") %]'
+  - filename: pe_checksum_fix.py
+    enable: '[% c("var/windows") %]'
   - filename: cert_override.txt
   - filename: tor-messenger.ico
     enable: '[% c("var/windows") %]'
@@ -44,10 +46,13 @@ var:
 targets:
   windows-i686:
     distribution: Ubuntu-14.10
+    arch: i686
     var:
       filename_ext: 'exe'
       arch_deps:
         - nsis
+        - python
+        - python-pefile
   osx-x86_64:
     distribution: Ubuntu-12.04
     var:

--- a/projects/tor-messenger/pe_checksum_fix.py
+++ b/projects/tor-messenger/pe_checksum_fix.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2015, The Tor Project, Inc.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#
+#     * Neither the names of the copyright owners nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""
+NSIS is neither padding nor calculating the PE-file checksum. But the tool
+we use for signing and the tools for stripping the signature do which leads to a
+SHA256 mismatch if one tries to check that the binary we offer is actually the
+the one we got from our reproducible builds.
+
+This small Python snippet does both things: It pads the .exe if necessary and it
+recalculates the PE-file checksum. Details of the discussion can be foun in bug
+15339: https://bugs.torproject.org/15539.
+
+Thanks to a cypherpunk for this workaround idea.
+"""
+
+import pefile;
+
+f = open('tor-messenger-install-tmp.exe')
+exe = f.read()
+f.close()
+remainder = len(exe) % 8
+if remainder > 0:
+    exe += '\0' * (8 - remainder)
+pef = pefile.PE(data=exe, fast_load=True)
+pef.OPTIONAL_HEADER.CheckSum = pef.generate_checksum()
+pef.write(filename='tor-messenger-install-tmp2.exe')


### PR DESCRIPTION
- Use the `pe_checksum_fix.py` script added in commit ​https://gitweb.torproject.org/builders/tor-browser-bundle.git/commit/?id=e487b6ffca7b023442fd8820eed8345a20310fde.

- Use `pip` to install `pefile` package since `python-pefile` from Ubuntu 14.10 is outdated and causes an error:
```
  File "/usr/lib/python2.7/dist-packages/pefile.py", line 3720, in generate_checksum
    dword = struct.unpack('L', self.__data__[ i*4 : i*4+4 ])[0]
error: unpack requires a string argument of length 8
```
(see https://github.com/brad-accuvant/cuckoo-modified/issues/186)