### PR TITLE
Bug23675: Trigger deletion of associated OTR keys when account is deleted

### DIFF
--- a/projects/instantbird/0001-Set-Tor-Messenger-preferences.patch
+++ b/projects/instantbird/0001-Set-Tor-Messenger-preferences.patch
@@ -1,7 +1,7 @@
-From 3aef7c8034e706afa8f0b3e31ecd03c8f9017ab4 Mon Sep 17 00:00:00 2001
+From 41aaed3bb12c9c6afae0bab3c796f115d4b87494 Mon Sep 17 00:00:00 2001
 From: Sukhbir Singh <sukhbir@torproject.org>
 Date: Wed, 26 Jul 2017 14:30:41 -0400
-Subject: [PATCH 01/22] Set Tor Messenger preferences
+Subject: [PATCH 01/23] Set Tor Messenger preferences
 
 ---
  im/app/profile/all-instantbird.js | 458 ++++++++++++++++++++++++++++++++++++--
@@ -565,5 +565,5 @@ index 127c86a662..31b3744c63 100644
 +#expand pref("torbrowser.version", __TOR_BROWSER_VERSION__);
 +#endif
 -- 
-2.14.1
+2.14.2
 

--- a/projects/instantbird/0002-Trac-21634-Autologin-default-should-be-false.patch
+++ b/projects/instantbird/0002-Trac-21634-Autologin-default-should-be-false.patch
@@ -1,7 +1,7 @@
-From ab5dabcf6221b83733482587c6ccdb3975b30b46 Mon Sep 17 00:00:00 2001
+From 604871aa5d771fa406543c43975072e76abfbfb3 Mon Sep 17 00:00:00 2001
 From: Arlo Breault <arlolra@gmail.com>
 Date: Mon, 16 Nov 2015 20:37:53 -0800
-Subject: [PATCH 02/22] Trac 21634: Autologin default should be false
+Subject: [PATCH 02/23] Trac 21634: Autologin default should be false
 
 ---
  chat/components/src/imAccounts.js | 2 +-
@@ -35,5 +35,5 @@ index d51df3225c..904d22ba57 100644
  
  </wizard>
 -- 
-2.14.1
+2.14.2
 

--- a/projects/instantbird/0003-XMPP-in-band-registration.patch
+++ b/projects/instantbird/0003-XMPP-in-band-registration.patch
@@ -1,7 +1,7 @@
-From 313ff42077e8a6aa6ca8acf9a659d991af64bdc3 Mon Sep 17 00:00:00 2001
+From 0e012453ee6b74ed3f9e1c17cf85cc934a134e0a Mon Sep 17 00:00:00 2001
 From: Sukhbir Singh <sukhbir@torproject.org>
 Date: Wed, 26 Jul 2017 15:09:40 -0400
-Subject: [PATCH 03/22] XMPP in-band registration
+Subject: [PATCH 03/23] XMPP in-band registration
 
 ---
  chat/locales/en-US/xmpp.properties                 |   5 +
@@ -392,5 +392,5 @@ index 43d0f19e3f..c46fb2f956 100644
 +
 +<!ENTITY registerXMPP.label "Create this new account on the server">
 -- 
-2.14.1
+2.14.2
 

--- a/projects/instantbird/0004-Remove-search-from-UI.patch
+++ b/projects/instantbird/0004-Remove-search-from-UI.patch
@@ -1,7 +1,7 @@
-From 5b47b35c62fe57b4e37b75efd9e116d6995c0b88 Mon Sep 17 00:00:00 2001
+From 1aaedf27cc861c6295a8bdc1b7af993bc645f3db Mon Sep 17 00:00:00 2001
 From: Sukhbir Singh <sukhbir@torproject.org>
 Date: Mon, 10 Oct 2016 18:47:48 -0700
-Subject: [PATCH 04/22] Remove search from UI
+Subject: [PATCH 04/23] Remove search from UI
 
 ---
  im/content/nsContextMenu.js         | 18 +-----------------
@@ -60,5 +60,5 @@ index fad67c190b..cfe2405ea3 100644
            <groupbox>
              <caption label="&configEditDesc.label;"/>
 -- 
-2.14.1
+2.14.2
 

--- a/projects/instantbird/0005-Add-Tor-Messenger-branding.patch
+++ b/projects/instantbird/0005-Add-Tor-Messenger-branding.patch
@@ -1,7 +1,7 @@
-From 38fa4bd0401bc9dbcba80a7fb1d51456dae0e3b1 Mon Sep 17 00:00:00 2001
+From 7b7666b7479b26c9ddb14b495e32c1a9c8d197ed Mon Sep 17 00:00:00 2001
 From: Sukhbir Singh <sukhbir@torproject.org>
 Date: Wed, 26 Jul 2017 15:46:51 -0400
-Subject: [PATCH 05/22] Add Tor Messenger branding
+Subject: [PATCH 05/23] Add Tor Messenger branding
 
 ---
  im/app/macbuild/Contents/Info.plist.in             |   2 +-
@@ -5121,5 +5121,5 @@ index 15ec569c11..4a2d35d8a1 100644
 -Info=Instantbird is installing your updates and will start in a few moments…
 +Info=Tor Messenger is installing your updates and will start in a few moments…
 -- 
-2.14.1
+2.14.2
 

--- a/projects/instantbird/0006-Remove-option-for-configuring-account-picture.patch
+++ b/projects/instantbird/0006-Remove-option-for-configuring-account-picture.patch
@@ -1,7 +1,7 @@
-From ca63ac2fee5d1cd4c07385c27951336ca044e0f1 Mon Sep 17 00:00:00 2001
+From eb65cd8cd1a6d4e968b4fa8c0a8442a702a1fb8c Mon Sep 17 00:00:00 2001
 From: Sukhbir Singh <sukhbir@torproject.org>
 Date: Mon, 10 Oct 2016 19:24:09 -0700
-Subject: [PATCH 06/22] Remove option for configuring account picture
+Subject: [PATCH 06/23] Remove option for configuring account picture
 
 ---
  im/content/blist.xul | 3 +--
@@ -22,5 +22,5 @@ index 843f1eef57..71ee2c9ef8 100644
          <panel id="changeUserIconPanel"
                 type="arrow" align="center"
 -- 
-2.14.1
+2.14.2
 

--- a/projects/instantbird/0007-Modify-top-protocol-defaults.patch
+++ b/projects/instantbird/0007-Modify-top-protocol-defaults.patch
@@ -1,7 +1,7 @@
-From 293de6a98f59314906fb493931e4da08c145edb9 Mon Sep 17 00:00:00 2001
+From 1979501a78c991b5d9ca6a69b31b060a736a41fc Mon Sep 17 00:00:00 2001
 From: Sukhbir Singh <sukhbir@torproject.org>
 Date: Wed, 26 Jul 2017 16:16:09 -0400
-Subject: [PATCH 07/22] Modify top protocol defaults
+Subject: [PATCH 07/23] Modify top protocol defaults
 
 ---
  im/content/accountWizard.xul | 2 +-
@@ -21,5 +21,5 @@ index 135b68386c..356321dbcc 100644
      </hbox>
    </wizardpage>
 -- 
-2.14.1
+2.14.2
 

--- a/projects/instantbird/0008-Modify-IRC-defaults.patch
+++ b/projects/instantbird/0008-Modify-IRC-defaults.patch
@@ -1,7 +1,7 @@
-From 5c4c225ebc5b63e6a4701bfa52857caf2ab0461d Mon Sep 17 00:00:00 2001
+From ed708539626304f7c400f50471180ad6c26e3f1b Mon Sep 17 00:00:00 2001
 From: Sukhbir Singh <sukhbir@torproject.org>
 Date: Mon, 10 Oct 2016 19:31:58 -0700
-Subject: [PATCH 08/22] Modify IRC defaults
+Subject: [PATCH 08/23] Modify IRC defaults
 
  * ctcp ping
 
@@ -61,5 +61,5 @@ index 43ed2ced4b..c2f16bee84 100644
                   ". Sending TIME response: \"" + now + "\".");
          this.sendCTCPMessage(aMessage.origin, true, "TIME", ":" + now);
 -- 
-2.14.1
+2.14.2
 

--- a/projects/instantbird/0009-Do-not-set-default-XMPP-server.patch
+++ b/projects/instantbird/0009-Do-not-set-default-XMPP-server.patch
@@ -1,7 +1,7 @@
-From 3a7c66ba02524914d909b32ce716586f775aaeca Mon Sep 17 00:00:00 2001
+From 6e366dac75dcc780c2c33995e9d2bca7c2573beb Mon Sep 17 00:00:00 2001
 From: Sukhbir Singh <sukhbir@torproject.org>
 Date: Fri, 28 Jul 2017 12:11:57 -0400
-Subject: [PATCH 09/22] Do not set default XMPP server
+Subject: [PATCH 09/23] Do not set default XMPP server
 
 ---
  chat/protocols/xmpp/xmpp.js | 2 +-
@@ -21,5 +21,5 @@ index 2afb15f059..1d2c167d3e 100644
  
    options: {
 -- 
-2.14.1
+2.14.2
 

--- a/projects/instantbird/0010-Modify-themes.patch
+++ b/projects/instantbird/0010-Modify-themes.patch
@@ -1,7 +1,7 @@
-From 466f8a545201f58e72d43bcf602251ab619fc189 Mon Sep 17 00:00:00 2001
+From 855eb4ecbc03a9105db7ec9a06378645608fe008 Mon Sep 17 00:00:00 2001
 From: Sukhbir Singh <sukhbir@torproject.org>
 Date: Mon, 10 Oct 2016 19:36:38 -0700
-Subject: [PATCH 10/22] Modify themes
+Subject: [PATCH 10/23] Modify themes
 
  * theme extension update
 
@@ -74,5 +74,5 @@ index 454e366960..18ba1f95cc 100644
            <separator class="thin"/>
            <description>&emoticonsPreview.description;</description>
 -- 
-2.14.1
+2.14.2
 

--- a/projects/instantbird/0011-Remove-logging-UI.patch
+++ b/projects/instantbird/0011-Remove-logging-UI.patch
@@ -1,7 +1,7 @@
-From 5951a00ada2bbc5dbf61b71ab339dc68646892fe Mon Sep 17 00:00:00 2001
+From 6001ad5a3e503cd1d4d327a9dafb8ad55d69d9ec Mon Sep 17 00:00:00 2001
 From: Sukhbir Singh <sukhbir@torproject.org>
 Date: Mon, 10 Oct 2016 19:50:48 -0700
-Subject: [PATCH 11/22] Remove logging UI
+Subject: [PATCH 11/23] Remove logging UI
 
 ---
  im/content/preferences/privacy.xul | 20 --------------------
@@ -39,5 +39,5 @@ index 7c9db1cdd8..2d7b2701ea 100644
      <groupbox id="passwordsGroup" orient="vertical">
        <caption label="&passwords.label;"/>
 -- 
-2.14.1
+2.14.2
 

--- a/projects/instantbird/0012-Cert-override.patch
+++ b/projects/instantbird/0012-Cert-override.patch
@@ -1,7 +1,7 @@
-From 015feb4d96762ffb6705091ef2713178702dcde2 Mon Sep 17 00:00:00 2001
+From ab0529b51943f0bff16c40dada3df661802fee07 Mon Sep 17 00:00:00 2001
 From: Sukhbir Singh <sukhbir@torproject.org>
 Date: Mon, 10 Oct 2016 19:56:46 -0700
-Subject: [PATCH 12/22] Cert override
+Subject: [PATCH 12/23] Cert override
 
 ---
  im/app/profile/cert_override.txt | 3 +++
@@ -60,5 +60,5 @@ index def78c809c..614d52bca2 100644
  #ifdef XP_MACOSX
  @RESPATH@/components/ibDockBadge.js
 -- 
-2.14.1
+2.14.2
 

--- a/projects/instantbird/0013-Display-all-traffic-over-Tor.patch
+++ b/projects/instantbird/0013-Display-all-traffic-over-Tor.patch
@@ -1,7 +1,7 @@
-From ccb6940299d87e001b392c10d028dfc3ac5b9516 Mon Sep 17 00:00:00 2001
+From 5bdd711e7237461ea415a1a461c22fd25aca5d88 Mon Sep 17 00:00:00 2001
 From: Sukhbir Singh <sukhbir@torproject.org>
 Date: Mon, 10 Oct 2016 19:58:31 -0700
-Subject: [PATCH 13/22] Display all traffic over Tor
+Subject: [PATCH 13/23] Display all traffic over Tor
 
 ---
  im/content/accountWizard.xul                          | 2 ++
@@ -34,5 +34,5 @@ index c46fb2f956..6b49c84fad 100644
  <!ENTITY accountProtocolShowMore.label  "Show all protocols">
  <!ENTITY accountProtocolShowMore.description  "Choose from the full list of protocols">
 -- 
-2.14.1
+2.14.2
 

--- a/projects/instantbird/0014-Trac-17480-Content-sink.patch
+++ b/projects/instantbird/0014-Trac-17480-Content-sink.patch
@@ -1,7 +1,7 @@
-From c8670c32a866081764149bf3fd6670192994d401 Mon Sep 17 00:00:00 2001
+From 803f1925c464db6226716e66a8be2da9b59c7e0d Mon Sep 17 00:00:00 2001
 From: Arlo Breault <arlolra@gmail.com>
 Date: Wed, 5 Oct 2016 11:09:25 -0700
-Subject: [PATCH 14/22] Trac 17480: Content sink
+Subject: [PATCH 14/23] Trac 17480: Content sink
 
 ---
  chat/modules/imContentSink.jsm     | 33 ++++++---------------------------
@@ -107,5 +107,5 @@ index 3b8ccfa2b3..ba41da76aa 100644
            <menuitem value="0" label="&filterLevelNone;"/>
          </menupopup>
 -- 
-2.14.1
+2.14.2
 

--- a/projects/instantbird/0015-SASL-ECDSA-NIST256P-CHALLENGE.patch
+++ b/projects/instantbird/0015-SASL-ECDSA-NIST256P-CHALLENGE.patch
@@ -1,7 +1,7 @@
-From ab0108edfd75b2f4741cf0080113887d697ddf4b Mon Sep 17 00:00:00 2001
+From 1f0d2e294494f134d9f85b226cc4f21664a692a9 Mon Sep 17 00:00:00 2001
 From: Arlo Breault <arlolra@gmail.com>
 Date: Sun, 2 Oct 2016 08:46:55 -0700
-Subject: [PATCH 15/22] SASL ECDSA-NIST256P-CHALLENGE
+Subject: [PATCH 15/23] SASL ECDSA-NIST256P-CHALLENGE
 
 ---
  chat/components/src/imAccounts.js |    1 +
@@ -8915,5 +8915,5 @@ index bc25396873..e46815dfe3 100644
      'ircCAP.jsm',
      'ircCommands.jsm',
 -- 
-2.14.1
+2.14.2
 

--- a/projects/instantbird/0016-Bug-1321641-Use-built-in-functions-instead-of-an-svg.patch
+++ b/projects/instantbird/0016-Bug-1321641-Use-built-in-functions-instead-of-an-svg.patch
@@ -1,7 +1,7 @@
-From 5589e17c4747a3c30edc3e5a980f80abac92c744 Mon Sep 17 00:00:00 2001
+From b812bbbeca94604c8696be5fc678009986f32062 Mon Sep 17 00:00:00 2001
 From: Arlo Breault <arlolra@gmail.com>
 Date: Tue, 29 Aug 2017 14:45:29 -0400
-Subject: [PATCH 16/22] Bug 1321641 - Use built-in functions instead of an svg
+Subject: [PATCH 16/23] Bug 1321641 - Use built-in functions instead of an svg
  for bubbles filter
 
 ---
@@ -53,5 +53,5 @@ index 80421b8ca2..6520757ddd 100644
  
  .indicator {
 -- 
-2.14.1
+2.14.2
 

--- a/projects/instantbird/0017-Bug-1321420-Add-a-pref-to-disable-JavaScript-in-brow.patch
+++ b/projects/instantbird/0017-Bug-1321420-Add-a-pref-to-disable-JavaScript-in-brow.patch
@@ -1,7 +1,7 @@
-From 75a58323c2964b36b0409a37249473f0ff39b803 Mon Sep 17 00:00:00 2001
+From 1c6d295dceb63bb0ed5d06f67a726f5d518fdfbf Mon Sep 17 00:00:00 2001
 From: Arlo Breault <arlolra@gmail.com>
 Date: Wed, 26 Jul 2017 16:35:33 -0400
-Subject: [PATCH 17/22] Bug 1321420 - Add a pref to disable JavaScript in
+Subject: [PATCH 17/23] Bug 1321420 - Add a pref to disable JavaScript in
  browser requests
 
 ---
@@ -48,5 +48,5 @@ index c52c8c637d..0069219fa6 100644
                                Components.interfaces.nsIWebProgress.NOTIFY_ALL);
    let url = request.url;
 -- 
-2.14.1
+2.14.2
 

--- a/projects/instantbird/0018-Trac-17517-Use-different-color-for-Add-Exception.patch
+++ b/projects/instantbird/0018-Trac-17517-Use-different-color-for-Add-Exception.patch
@@ -1,7 +1,7 @@
-From baeb48bfa3e1185a533b3576c6c1afd653d963cf Mon Sep 17 00:00:00 2001
+From efdda1554011fbe0f3e06f2ab897ef33577f3aca Mon Sep 17 00:00:00 2001
 From: Vu Quoc Huy <huyvq.c633@gmail.com>
 Date: Wed, 26 Jul 2017 16:38:19 -0400
-Subject: [PATCH 18/22] Trac 17517 - Use different color for Add Exception
+Subject: [PATCH 18/23] Trac 17517 - Use different color for Add Exception
 
 ---
  chat/content/accounts.css | 3 +++
@@ -19,5 +19,5 @@ index 807184209b..8ce7f9ad81 100644
 +  color: #fff;
 +}
 -- 
-2.14.1
+2.14.2
 

--- a/projects/instantbird/0019-Trac-21736-Hide-account-timestamp-from-message.patch
+++ b/projects/instantbird/0019-Trac-21736-Hide-account-timestamp-from-message.patch
@@ -1,7 +1,7 @@
-From 1f7835fa96fb79e580ff76508bdebe6fe294f101 Mon Sep 17 00:00:00 2001
+From 2ee58d3cdaf07280ece4a0745deca5284ca0f408 Mon Sep 17 00:00:00 2001
 From: Vu Quoc Huy <huyvq.c633@gmail.com>
 Date: Sun, 2 Apr 2017 13:07:09 -0400
-Subject: [PATCH 19/22] Trac 21736 - Hide account/timestamp from message
+Subject: [PATCH 19/23] Trac 21736 - Hide account/timestamp from message
 
 ---
  chat/modules/imThemes.jsm         | 9 ++++-----
@@ -60,5 +60,5 @@ index 31b3744c63..98e1a7b929 100644
  /* This Source Code Form is subject to the terms of the Mozilla Public
   * License, v. 2.0. If a copy of the MPL was not distributed with this
 -- 
-2.14.1
+2.14.2
 

--- a/projects/instantbird/0020-Update-allowed-duplicated-files-for-Windows-and-Linu.patch
+++ b/projects/instantbird/0020-Update-allowed-duplicated-files-for-Windows-and-Linu.patch
@@ -1,7 +1,7 @@
-From 6e26c435c18d09198b94ed772ff4e1840d1338b2 Mon Sep 17 00:00:00 2001
+From 8ee4eb4163d3dda4f7a301b4fbf6e13162ec4e92 Mon Sep 17 00:00:00 2001
 From: Sukhbir Singh <sukhbir@torproject.org>
 Date: Thu, 27 Jul 2017 15:16:54 -0400
-Subject: [PATCH 20/22] Update allowed duplicated files for Windows and Linux
+Subject: [PATCH 20/23] Update allowed duplicated files for Windows and Linux
  builds
 
 ---
@@ -94,5 +94,5 @@ index 988dc2d35a..940418bc9d 100644
  # Variants of paths in mozilla/browser/installer/allowed-dupes.mn
  # and mail/installer/allowed-dupes.mn:
 -- 
-2.14.1
+2.14.2
 

--- a/projects/instantbird/0021-Bug-13855-Use-known-onions-for-XMPP-servers.patch
+++ b/projects/instantbird/0021-Bug-13855-Use-known-onions-for-XMPP-servers.patch
@@ -1,7 +1,7 @@
-From 3420f52e84a8902eee7394e98474781fd02014ce Mon Sep 17 00:00:00 2001
+From bcea55730ea343eff80b402febb27e0ae1957bee Mon Sep 17 00:00:00 2001
 From: Sukhbir Singh <sukhbir@torproject.org>
 Date: Tue, 15 Aug 2017 16:40:33 -0400
-Subject: [PATCH 21/22] Bug 13855: Use known onions for XMPP servers
+Subject: [PATCH 21/23] Bug 13855: Use known onions for XMPP servers
 
 ---
  im/content/accountWizard.js                        | 42 +++++++++++++++++++++-
@@ -138,5 +138,5 @@ index efb0b77aee..05a4deb462 100644
 +
 +onionAddress.label=%S is %S's onion address.
 -- 
-2.14.1
+2.14.2
 

--- a/projects/instantbird/0022-Bug-16606-Automatic-XMPP-accounts.patch
+++ b/projects/instantbird/0022-Bug-16606-Automatic-XMPP-accounts.patch
@@ -1,7 +1,7 @@
-From e3150c2c9018a68b1582a2c30c7e6821ea223c64 Mon Sep 17 00:00:00 2001
+From 623410fa25aa0fc129770e52ebab67e6e5922208 Mon Sep 17 00:00:00 2001
 From: Sukhbir Singh <sukhbir@torproject.org>
 Date: Mon, 21 Aug 2017 23:00:07 -0400
-Subject: [PATCH 22/22] Bug 16606: Automatic XMPP accounts
+Subject: [PATCH 22/23] Bug 16606: Automatic XMPP accounts
 
 Add support for "temporary" XMPP accounts for which the username and
 password are randomly generated and in-band registration is performed
@@ -166,5 +166,5 @@ index 6b49c84fad..de7fe8ed11 100644
  <!ENTITY registerXMPP.label "Create this new account on the server">
 +<!ENTITY tempXMPP.label "Create a temporary account automatically">
 -- 
-2.14.1
+2.14.2
 

--- a/projects/instantbird/0023-Bug-23675-Attach-protocol-info-when-firing-account-r.patch
+++ b/projects/instantbird/0023-Bug-23675-Attach-protocol-info-when-firing-account-r.patch
@@ -1,0 +1,31 @@
+From 8831b24b1503e1011d8f0e76e80bdc1929890f0b Mon Sep 17 00:00:00 2001
+From: Vu Quoc Huy <huyvq.c633@gmail.com>
+Date: Fri, 6 Oct 2017 00:29:16 +0200
+Subject: [PATCH 23/23] Bug 23675 - Attach protocol info when firing
+ account-removed event
+
+Used in ctypes-otr to find the removed account
+---
+ chat/components/src/imAccounts.js | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/chat/components/src/imAccounts.js b/chat/components/src/imAccounts.js
+index 7b5a3ab040..110fa303fa 100644
+--- a/chat/components/src/imAccounts.js
++++ b/chat/components/src/imAccounts.js
+@@ -1078,10 +1078,11 @@ AccountsService.prototype = {
+       throw Cr.NS_ERROR_UNEXPECTED;
+ 
+     let id = account.numericId;
++    let prplId = account.protocol.id;
+     account.remove();
+     this._accounts.splice(index, 1);
+     delete this._accountsById[id];
+-    Services.obs.notifyObservers(account, "account-removed", null);
++    Services.obs.notifyObservers(account, "account-removed", prplId);
+ 
+     /* Update the account list pref. */
+     let list = this._accountList;
+-- 
+2.14.2
+

--- a/projects/instantbird/config
+++ b/projects/instantbird/config
@@ -71,6 +71,7 @@ input_files:
   - filename: 0020-Update-allowed-duplicated-files-for-Windows-and-Linu.patch
   - filename: 0021-Bug-13855-Use-known-onions-for-XMPP-servers.patch
   - filename: 0022-Bug-16606-Automatic-XMPP-accounts.patch
+  - filename: 0023-Bug-23675-Attach-protocol-info-when-firing-account-r.patch
   - filename: get-moz-build-date
   - filename: mozconfig-common
   - filename: 'mozconfig-[% c("var/osname") %]'


### PR DESCRIPTION
Attach protocol ID when firing the account-removed event so we can use it in ctypes-otr to trigger deletion of associated keys.
Ref: https://github.com/arlolra/ctypes-otr/pull/95